### PR TITLE
Add Windows path policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Key Flags (prototype)
 
 - `--write-report`: write a summary to `.git/filter-repo/report.txt`.
 - `--cleanup [none|standard|aggressive]`: post-import cleanup (reflog expire + gc). Default `none`.
+- `--windows-path-policy [sanitize|skip|error]`: control how Windows-incompatible paths are handled
+  when rebuilding filechanges. `sanitize` (default) rewrites to safe names and records the mapping in
+  the report; `skip` keeps the original names; `error` aborts the run when such paths are encountered.
 - `--quiet`, `--no-reset`: reduce noise / skip post-import reset
 - `--no-reencode`, `--no-quotepath`, `--no-mark-tags`: pass-through fast-export toggles
 - `--backup`: create a git bundle of the selected refs under `.git/filter-repo/` (skipped in `--dry-run`).
@@ -130,7 +133,8 @@ Limitations (prototype)
 - No regex path matching; glob/prefix only.
 - Merge simplification not implemented; we preserve merges but don't trim extra parents.
 - No `--state-branch` yet; marks exported to a file.
-- Windows path policy is always "sanitize" for rebuilt lines (no skip/error modes yet).
+- Windows path sanitization is limited to adjusting characters Windows forbids and trimming trailing
+  dots/spaces; it does not currently detect every possible reserved device name.
 
 Examples
 --------

--- a/filter-repo-rs/src/commit.rs
+++ b/filter-repo-rs/src/commit.rs
@@ -128,7 +128,7 @@ pub fn process_commit_line(
   }
   // file changes with path filtering
   if line.starts_with(b"M ") || line.starts_with(b"D ") || line.starts_with(b"C ") || line.starts_with(b"R ") || line == b"deleteall\n" {
-    if let Some(newline) = filechange::handle_file_change_line(line, opts) {
+    if let Some(newline) = filechange::handle_file_change_line(line, opts)? {
       commit_buf.extend_from_slice(&newline);
       *commit_has_changes = true;
     }

--- a/filter-repo-rs/src/finalize.rs
+++ b/filter-repo-rs/src/finalize.rs
@@ -10,12 +10,13 @@ use crate::stream::BlobSizeTracker;
 
 #[derive(Debug)]
 pub struct ReportData {
-    pub stripped_by_size: usize,
-    pub stripped_by_sha: usize,
-    pub modified_blobs: usize,
-    pub samples_size: Vec<Vec<u8>>,     // paths
-    pub samples_sha: Vec<Vec<u8>>,      // paths
-    pub samples_modified: Vec<Vec<u8>>, // paths
+  pub stripped_by_size: usize,
+  pub stripped_by_sha: usize,
+  pub modified_blobs: usize,
+  pub samples_size: Vec<Vec<u8>>,     // paths
+  pub samples_sha: Vec<Vec<u8>>,      // paths
+  pub samples_modified: Vec<Vec<u8>>, // paths
+  pub sanitized_windows_paths: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
 // Flush buffered lightweight tag resets to outputs prior to sending 'done'.
@@ -556,6 +557,15 @@ pub fn finalize(
                 writeln!(f, "\nSample paths (modified):")?;
                 for p in r.samples_modified {
                     f.write_all(&p)?;
+                    f.write_all(b"\n")?;
+                }
+            }
+            if !r.sanitized_windows_paths.is_empty() {
+                writeln!(f, "\nPaths sanitized for Windows compatibility:")?;
+                for (orig, sanitized) in r.sanitized_windows_paths {
+                    f.write_all(&orig)?;
+                    f.write_all(b" -> ")?;
+                    f.write_all(&sanitized)?;
                     f.write_all(b"\n")?;
                 }
             }

--- a/filter-repo-rs/src/lib.rs
+++ b/filter-repo-rs/src/lib.rs
@@ -13,7 +13,7 @@ mod sanity;
 mod migrate;
 pub mod analysis;
 
-pub use opts::{AnalyzeConfig, AnalyzeThresholds, Mode, Options};
+pub use opts::{AnalyzeConfig, AnalyzeThresholds, Mode, Options, WindowsPathPolicy};
 pub use pathutil::dequote_c_style_bytes;
 
 pub fn run(opts: &Options) -> std::io::Result<()> {

--- a/filter-repo-rs/src/pathutil.rs
+++ b/filter-repo-rs/src/pathutil.rs
@@ -1,27 +1,22 @@
 #[allow(dead_code)]
-#[cfg(windows)]
 pub fn sanitize_invalid_windows_path_bytes(p: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(p.len());
-    for &b in p {
-        let nb = match b { b'<'|b'>'|b':'|b'"'|b'|'|b'?'|b'*' => b'_', _ => b };
-        out.push(nb);
-    }
-    if let Some(pos) = out.rsplit(|&c| c == b'/').next().map(|comp| out.len() - comp.len()) {
-        let (head, tail) = out.split_at(pos);
-        let mut t = tail.to_vec();
-        while t.last().map_or(false, |c| *c == b'.' || *c == b' ') { t.pop(); }
-        let mut combined = head.to_vec();
-        combined.extend_from_slice(&t);
-        return combined;
-    }
-    let mut o = out;
-    while o.last().map_or(false, |c| *c == b'.' || *c == b' ') { o.pop(); }
-    o
+  let mut out = Vec::with_capacity(p.len());
+  for &b in p {
+    let nb = match b { b'<' | b'>' | b':' | b'"' | b'|' | b'?' | b'*' => b'_', _ => b };
+    out.push(nb);
+  }
+  if let Some(pos) = out.rsplit(|&c| c == b'/').next().map(|comp| out.len() - comp.len()) {
+    let (head, tail) = out.split_at(pos);
+    let mut t = tail.to_vec();
+    while t.last().map_or(false, |c| *c == b'.' || *c == b' ') { t.pop(); }
+    let mut combined = head.to_vec();
+    combined.extend_from_slice(&t);
+    return combined;
+  }
+  let mut o = out;
+  while o.last().map_or(false, |c| *c == b'.' || *c == b' ') { o.pop(); }
+  o
 }
-
-#[allow(dead_code)]
-#[cfg(not(windows))]
-pub fn sanitize_invalid_windows_path_bytes(p: &[u8]) -> Vec<u8> { p.to_vec() }
 
 #[allow(dead_code)]
 pub fn dequote_c_style_bytes(s: &[u8]) -> Vec<u8> {

--- a/filter-repo-rs/src/stream.rs
+++ b/filter-repo-rs/src/stream.rs
@@ -347,6 +347,9 @@ pub fn run(opts: &Options) -> io::Result<()> {
     if !debug_dir.exists() {
         create_dir_all(&debug_dir)?;
     }
+    if let Ok(mut guard) = opts.sanitized_windows_paths.lock() {
+        guard.clear();
+    }
     let mut orig_file = File::create(debug_dir.join("fast-export.original"))?;
     let mut filt_file = File::create(debug_dir.join("fast-export.filtered"))?;
 
@@ -1170,6 +1173,11 @@ pub fn run(opts: &Options) -> io::Result<()> {
             if sha_cnt == 0 {
                 sha_cnt = suppressed_marks_by_sha.len();
             }
+            let sanitized_paths = opts
+                .sanitized_windows_paths
+                .lock()
+                .map(|g| g.clone())
+                .unwrap_or_else(|_| Vec::new());
             Some(crate::finalize::ReportData {
                 stripped_by_size: size_cnt,
                 stripped_by_sha: sha_cnt,
@@ -1177,6 +1185,7 @@ pub fn run(opts: &Options) -> io::Result<()> {
                 samples_size,
                 samples_sha,
                 samples_modified,
+                sanitized_windows_paths: sanitized_paths,
             })
         },
         &blob_size_tracker,
@@ -1190,41 +1199,11 @@ mod tests {
     use tempfile::TempDir;
 
     fn create_test_opts(source: &str) -> Options {
-        Options {
-            source: PathBuf::from(source),
-            target: PathBuf::from("."),
-            refs: vec!["--all".to_string()],
-            date_order: false,
-            no_data: false,
-            quiet: false,
-            reset: true,
-            replace_message_file: None,
-            replace_text_file: None,
-            paths: Vec::new(),
-            invert_paths: false,
-            path_globs: Vec::new(),
-            path_renames: Vec::new(),
-            tag_rename: None,
-            branch_rename: None,
-            max_blob_size: None,
-            strip_blobs_with_ids: None,
-            write_report: false,
-            cleanup: crate::opts::CleanupMode::None,
-            reencode: true,
-            quotepath: true,
-            mark_tags: true,
-            fe_stream_override: None,
-            force: false,
-            enforce_sanity: false,
-            dry_run: false,
-            partial: false,
-            sensitive: false,
-            no_fetch: false,
-            backup: false,
-            backup_path: None,
-            mode: crate::opts::Mode::Filter,
-            analyze: crate::opts::AnalyzeConfig::default(),
-        }
+        let mut opts = Options::default();
+        opts.source = PathBuf::from(source);
+        opts.target = PathBuf::from(".");
+        opts.refs = vec!["--all".to_string()];
+        opts
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a `WindowsPathPolicy` CLI flag to control how Windows-incompatible paths are handled during rewrites
- apply the policy when rewriting filechange paths, record sanitized names for the report, and clear samples per run
- document the new flag and cover sanitize/skip/error behaviors in integration tests

## Testing
- cargo test -p filter-repo-rs

------
https://chatgpt.com/codex/tasks/task_e_68cc191029948332b249510e41acda8f