### PR TITLE
Gate fast-export passthrough flags behind debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ CLI overview (selected)
 
 - Repository & refs
   - `--source DIR`, `--target DIR` (default `.`), `--refs` (repeatable, defaults to `--all`)
-  - `--date-order`, `--no-data` forwarded to fast-export
+  - `--no-data` forwarded to fast-export
 
 - Paths
   - `--path`, `--path-glob`, `--path-regex`, `--invert-paths`
@@ -212,9 +212,11 @@ CLI overview (selected)
 
 - Behavior & output
   - `--write-report`, `--cleanup [none|standard|aggressive]`, `--quiet`, `--no-reset`
-  - `--no-reencode`, `--no-quotepath`, `--no-mark-tags`, `--mark-tags`
   - `--backup [--backup-path PATH]`, `--dry-run`
   - `--partial`, `--sensitive [--no-fetch]`, `--force`, `--enforce-sanity`
+
+- Debug / fast-export passthrough *(requires `--debug-mode` or `FRRS_DEBUG=1`)*
+  - `--date-order`, `--no-reencode`, `--no-quotepath`, `--no-mark-tags`, `--mark-tags`
 
 Examples
 --------

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -197,7 +197,7 @@ cargo test -p filter-repo-rs
 
 - 仓库与引用
   - `--source DIR`、`--target DIR`（默认 `.`）、`--refs`（可重复，默认 `--all`）
-  - `--date-order`、`--no-data` 透传给 fast-export
+  - `--no-data` 透传给 fast-export
 
 - 路径
   - `--path`、`--path-glob`、`--path-regex`、`--invert-paths`
@@ -211,9 +211,11 @@ cargo test -p filter-repo-rs
 
 - 行为与输出
   - `--write-report`、`--cleanup [none|standard|aggressive]`、`--quiet`、`--no-reset`
-  - `--no-reencode`、`--no-quotepath`、`--no-mark-tags`、`--mark-tags`
   - `--backup [--backup-path PATH]`、`--dry-run`
   - `--partial`、`--sensitive [--no-fetch]`、`--force`、`--enforce-sanity`
+
+- 调试 / fast-export 透传（需要 `--debug-mode` 或 `FRRS_DEBUG=1`）
+  - `--date-order`、`--no-reencode`、`--no-quotepath`、`--no-mark-tags`、`--mark-tags`
 
 示例
 ----

--- a/docs/ISSUE-CHECKLIST.md
+++ b/docs/ISSUE-CHECKLIST.md
@@ -8,7 +8,7 @@ Legend: [ ] todo, [~] in progress, [x] done
 1) Gating & Help Layering
 - [ ] Add `--debug-mode` flag and/or `FRRS_DEBUG=1` env to expose hidden/debug flags in `--help`.
 - [ ] Split help output: default (core) vs verbose/debug (hidden).
-- [ ] Hide fast‑export low‑level flags (`--no-reencode`, `--no-quotepath`, `--mark-tags/--no-mark-tags`, `--date-order`) unless in debug.
+- [x] Hide fast‑export low‑level flags (`--no-reencode`, `--no-quotepath`, `--mark-tags/--no-mark-tags`, `--date-order`) unless in debug.
 - [ ] Hide `--no-reset`, `--cleanup=aggressive` unless in debug.
 - [ ] Mark `--fe_stream_override` as test‑only (undocumented) unless in debug.
 
@@ -34,13 +34,13 @@ Legend: [ ] todo, [~] in progress, [x] done
 - [ ] Add regression tests for defaults on Windows/Linux/macOS.
 
 6) Docs & Examples
-- [ ] Update README.md / README.zh-CN.md CLI sections to reflect core set.
+- [x] Update README.md / README.zh-CN.md CLI sections to reflect core set.
 - [ ] Link SCOPE & PARITY prominently; add a “Quick recipes” subset.
 - [ ] Provide sample `.filter-repo-rs.toml` in docs and tests.
 - [ ] Update docs/STATUS.md with progress ticks.
 
 7) Tests
-- [ ] Unit tests for gating (`--help`, debug exposure).
+- [x] Unit tests for gating (`--help`, debug exposure).
 - [ ] Integration tests for `--cleanup` semantics.
 - [ ] Config precedence tests (config vs CLI).
 - [ ] Backward‑compat acceptance of deprecated flags with warnings.

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -109,7 +109,7 @@ These options are low‑frequency in real workflows or feel like plumbing/test t
 
 - Fast‑export passthrough / low‑level knobs
   - `--no-reencode`, `--no-quotepath`, `--mark-tags/--no-mark-tags`, `--date-order`.
-  - Proposal: pick sane defaults and hide behind a debug/test mode.
+  - Proposal: pick sane defaults and hide behind a debug/test mode. (Status: gated behind `--debug-mode` / `FRRS_DEBUG`.)
 - Post‑import behavior micro‑switches
   - `--no-reset`, `--cleanup [none|standard|aggressive]`.
   - Proposal: simplify to a boolean `--cleanup` (or default “standard”); keep `--no-reset` only for debugging (or imply via `--dry-run`).

--- a/docs/SCOPE.zh-CN.md
+++ b/docs/SCOPE.zh-CN.md
@@ -109,7 +109,7 @@ Python 原版特有、可不对齐的项
 
 - fast‑export 直通/底层细节开关
   - `--no-reencode`、`--no-quotepath`、`--mark-tags/--no-mark-tags`、`--date-order`
-  - 建议：选用合理默认并隐藏开关（仅用于测试或故障排查）。
+  - 建议：选用合理默认并隐藏开关（仅用于测试或故障排查）。【现状：已通过 `--debug-mode` / `FRRS_DEBUG` 隐藏。】
 - 导入后行为小开关
   - `--no-reset`、`--cleanup [none|standard|aggressive]`
   - 建议：简化为布尔 `--cleanup` 或仅保留 standard；`--no-reset` 仅调试可见（或由 `--dry-run` 隐含）。

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,6 +11,7 @@ A minimal Rust prototype of git-filter-repo is working end-to-end on real reposi
   - Saves debug copies at `.git/filter-repo/fast-export.{original,filtered}`.
   - Fast-export flags: `--show-original-ids --signed-tags=strip --tag-of-filtered-object=rewrite --fake-missing-tagger --reference-excluded-parents --use-done-feature`.
   - Also enabled: `-c core.quotepath=false`, `--reencode=yes`, `--mark-tags`.
+  - Debug gating: `--debug-mode` / `FRRS_DEBUG` exposes fast-export passthrough knobs and analysis thresholds; baseline `--help` hides them.
   - Fast-import runs with `-c core.ignorecase=false` and exports marks to `.git/filter-repo/target-marks`.
 
 - Refactor & Module Layout

--- a/docs/cli-convergence.md
+++ b/docs/cli-convergence.md
@@ -10,7 +10,7 @@ assignees: []
 
 - [ ] Add `--debug-mode` and/or `FRRS_DEBUG=1` to expose hidden/debug flags in `--help`.
 - [ ] Help layering: default (core) vs verbose/debug (hidden) output.
-- [ ] Hide fast‑export low‑level flags unless debug: `--no-reencode`, `--no-quotepath`, `--mark-tags/--no-mark-tags`, `--date-order`.
+- [x] Hide fast‑export low‑level flags unless debug: `--no-reencode`, `--no-quotepath`, `--mark-tags/--no-mark-tags`, `--date-order`.
 - [ ] Hide `--no-reset` and keep `--cleanup-aggressive` only under debug.
 - [ ] Make `--cleanup` boolean (standard), wire finalize path.
 - [ ] Config support for analysis thresholds (`.filter-repo-rs.toml`), CLI overrides config.

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -8,7 +8,7 @@ fn cli_command() -> Command {
 }
 
 #[test]
-fn help_hides_analysis_thresholds_without_debug() {
+fn help_hides_debug_sections_without_debug_mode() {
     let output = cli_command()
         .arg("--help")
         .output()
@@ -28,10 +28,22 @@ fn help_hides_analysis_thresholds_without_debug() {
         !stdout.contains("--analyze-total-warn"),
         "baseline help should hide threshold overrides"
     );
+    assert!(
+        !stdout.contains("Debug / fast-export passthrough"),
+        "baseline help should hide fast-export passthrough header"
+    );
+    assert!(
+        !stdout.contains("--no-reencode"),
+        "baseline help should hide fast-export passthrough flags"
+    );
+    assert!(
+        !stdout.contains("--date-order"),
+        "baseline help should hide date-order toggle"
+    );
 }
 
 #[test]
-fn help_shows_analysis_thresholds_in_debug_mode() {
+fn help_shows_debug_sections_in_debug_mode() {
     let output = cli_command()
         .arg("--debug-mode")
         .arg("--help")
@@ -50,6 +62,14 @@ fn help_shows_analysis_thresholds_in_debug_mode() {
     assert!(
         stdout.contains("Debug / analysis thresholds"),
         "debug section header missing"
+    );
+    assert!(
+        stdout.contains("Debug / fast-export passthrough"),
+        "debug help should list fast-export passthrough header"
+    );
+    assert!(
+        stdout.contains("--no-reencode"),
+        "debug help should list fast-export passthrough flags"
     );
 }
 
@@ -74,10 +94,42 @@ fn analysis_threshold_flags_require_debug_mode() {
 }
 
 #[test]
+fn fast_export_debug_flags_require_debug_mode() {
+    let output = cli_command()
+        .arg("--date-order")
+        .output()
+        .expect("run filter-repo-rs with gated fast-export flag");
+
+    assert_eq!(
+        Some(2),
+        output.status.code(),
+        "gated fast-export flag should exit with code 2"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("FRRS_DEBUG"),
+        "gated message should mention FRRS_DEBUG"
+    );
+}
+
+#[test]
+fn debug_mode_allows_fast_export_debug_flags() {
+    let output = cli_command()
+        .arg("--debug-mode")
+        .arg("--date-order")
+        .arg("--help")
+        .output()
+        .expect("run filter-repo-rs --debug-mode --date-order --help");
+
+    assert!(output.status.success(), "debug mode should allow fast-export flag");
+}
+
+#[test]
 fn debug_mode_allows_analysis_threshold_flags() {
     let repo = init_repo();
     let output = cli_command()
         .arg("--debug-mode")
+        .arg("--date-order")
         .arg("--analyze")
         .arg("--analyze-total-warn")
         .arg("1")

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -99,33 +99,69 @@ fn analysis_threshold_flags_require_debug_mode() {
 
 #[test]
 fn fast_export_debug_flags_require_debug_mode() {
-    let output = cli_command()
-        .arg("--date-order")
-        .output()
-        .expect("run filter-repo-rs with gated fast-export flag");
+    let gated_flags = [
+        "--date-order",
+        "--no-reencode",
+        "--no-quotepath",
+        "--no-mark-tags",
+        "--mark-tags",
+    ];
 
-    assert_eq!(
-        Some(2),
-        output.status.code(),
-        "gated fast-export flag should exit with code 2"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("FRRS_DEBUG"),
-        "gated message should mention FRRS_DEBUG"
-    );
+    for flag in gated_flags {
+        let output = cli_command()
+            .arg(flag)
+            .output()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to run filter-repo-rs with gated flag {}: {}",
+                    flag, e
+                )
+            });
+
+        assert_eq!(
+            Some(2),
+            output.status.code(),
+            "gated fast-export flag '{}' should exit with code 2",
+            flag
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("FRRS_DEBUG"),
+            "gated message for flag '{}' should mention FRRS_DEBUG",
+            flag
+        );
+    }
 }
 
 #[test]
 fn debug_mode_allows_fast_export_debug_flags() {
-    let output = cli_command()
-        .arg("--debug-mode")
-        .arg("--date-order")
-        .arg("--help")
-        .output()
-        .expect("run filter-repo-rs --debug-mode --date-order --help");
+    let gated_flags = [
+        "--date-order",
+        "--no-reencode",
+        "--no-quotepath",
+        "--no-mark-tags",
+        "--mark-tags",
+    ];
 
-    assert!(output.status.success(), "debug mode should allow fast-export flag");
+    for flag in gated_flags {
+        let output = cli_command()
+            .arg("--debug-mode")
+            .arg(flag)
+            .arg("--help")
+            .output()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to run filter-repo-rs --debug-mode with flag {}: {}",
+                    flag, e
+                )
+            });
+
+        assert!(
+            output.status.success(),
+            "debug mode should allow fast-export flag '{}'",
+            flag
+        );
+    }
 }
 
 #[test]

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -71,6 +71,10 @@ fn help_shows_debug_sections_in_debug_mode() {
         stdout.contains("--no-reencode"),
         "debug help should list fast-export passthrough flags"
     );
+    assert!(
+        stdout.contains("--date-order"),
+        "debug help should also list date-order toggle"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- gate fast-export passthrough toggles behind `--debug-mode` / `FRRS_DEBUG`, update help layering, and extend CLI tests for the new gating
- refresh README, scope, and status docs to show the debug-only surface and mark the checklist item complete

## Testing
- cargo test -p filter-repo-rs

------
https://chatgpt.com/codex/tasks/task_e_68cf764821f08332b3b52387aa27f5bf