### PR TITLE
Gate debug-only options behind debug mode

### DIFF
--- a/filter-repo-rs/src/opts.rs
+++ b/filter-repo-rs/src/opts.rs
@@ -217,7 +217,10 @@ pub fn parse_args() -> Options {
       }
       "--no-data" => opts.no_data = true,
       "--quiet" => opts.quiet = true,
-      "--no-reset" => opts.reset = false,
+      "--no-reset" => {
+        guard_debug("--no-reset", opts.debug_mode);
+        opts.reset = false;
+      }
       "--replace-message" => {
         let p = it.next().expect("--replace-message requires file");
         opts.replace_message_file = Some(PathBuf::from(p));
@@ -318,6 +321,10 @@ pub fn parse_args() -> Options {
           }
         };
       }
+      "--cleanup-aggressive" => {
+        guard_debug("--cleanup-aggressive", opts.debug_mode);
+        opts.cleanup = CleanupMode::Aggressive;
+      }
       "--no-reencode" => {
         guard_debug("--no-reencode", opts.debug_mode);
         opts.reencode = false;
@@ -362,6 +369,11 @@ pub fn parse_args() -> Options {
           eprintln!("error: --backup-path requires a value");
           std::process::exit(2);
         }
+      }
+      "--fe_stream_override" => {
+        guard_debug("--fe_stream_override", opts.debug_mode);
+        let p = it.next().expect("--fe_stream_override requires FILE");
+        opts.fe_stream_override = Some(PathBuf::from(p));
       }
       "-h" | "--help" => {
         print_help(opts.debug_mode);
@@ -449,7 +461,6 @@ Execution behavior & output:\n\
   --write-report              Write .git/filter-repo/report.txt summary\n\
   --cleanup MODE              none|standard|aggressive (default: none)\n\
   --quiet                     Reduce output noise\n\
-  --no-reset                  Skip final 'git reset --hard' in target\n\
   --force, -f                 Bypass safety prompts and checks where applicable\n\
   --enforce-sanity            Fail early unless repo passes strict preflight\n\
   --dry-run                   Prepare and validate without writing changes\n\
@@ -497,6 +508,17 @@ Debug / analysis thresholds (require --debug-mode or FRRS_DEBUG=1):\n\
   --analyze-max-parents-warn N Override max parent count warning threshold\n\
 ";
 
+const DEBUG_CLEANUP_HELP: &str = "\n\
+Debug / cleanup behavior (require --debug-mode or FRRS_DEBUG=1):\n\
+  --no-reset                  Skip final 'git reset --hard' in target\n\
+  --cleanup-aggressive        Apply aggressive cleanup routines after filtering\n\
+";
+
+const DEBUG_STREAM_HELP: &str = "\n\
+Debug / stream overrides (require --debug-mode or FRRS_DEBUG=1):\n\
+  --fe_stream_override FILE   Read fast-export stream from FILE instead of git\n\
+";
+
 const MISC_HELP: &str = "\n\
 Misc:\n\
   --debug-mode               Enable debug/test flags (same as FRRS_DEBUG=1)\n\
@@ -509,6 +531,8 @@ pub fn print_help(debug_mode: bool) {
   if debug_mode {
     print!("{}", DEBUG_FAST_EXPORT_HELP);
     print!("{}", DEBUG_ANALYSIS_HELP);
+    print!("{}", DEBUG_CLEANUP_HELP);
+    print!("{}", DEBUG_STREAM_HELP);
   }
   print!("{}", MISC_HELP);
 }

--- a/filter-repo-rs/src/stream.rs
+++ b/filter-repo-rs/src/stream.rs
@@ -359,9 +359,8 @@ pub fn run(opts: &Options) -> io::Result<()> {
     let mut orig_file = File::create(debug_dir.join("fast-export.original"))?;
     let mut filt_file = File::create(debug_dir.join("fast-export.filtered"))?;
 
-    let mut fe = crate::pipes::build_fast_export_cmd(opts)
-        .spawn()
-        .expect("failed to spawn git fast-export");
+    let mut fe_cmd = crate::pipes::build_fast_export_cmd(opts)?;
+    let mut fe = fe_cmd.spawn().expect("failed to spawn git fast-export");
     let mut fi = if opts.dry_run {
         None
     } else {

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -40,6 +40,26 @@ fn help_hides_debug_sections_without_debug_mode() {
         !stdout.contains("--date-order"),
         "baseline help should hide date-order toggle"
     );
+    assert!(
+        !stdout.contains("--no-reset"),
+        "baseline help should hide cleanup debug flag"
+    );
+    assert!(
+        !stdout.contains("--cleanup-aggressive"),
+        "baseline help should hide aggressive cleanup toggle"
+    );
+    assert!(
+        !stdout.contains("--fe_stream_override"),
+        "baseline help should hide stream override"
+    );
+    assert!(
+        !stdout.contains("Debug / cleanup behavior"),
+        "baseline help should hide cleanup debug section"
+    );
+    assert!(
+        !stdout.contains("Debug / stream overrides"),
+        "baseline help should hide stream override section"
+    );
 }
 
 #[test]
@@ -75,6 +95,26 @@ fn help_shows_debug_sections_in_debug_mode() {
         stdout.contains("--date-order"),
         "debug help should also list date-order toggle"
     );
+    assert!(
+        stdout.contains("Debug / cleanup behavior"),
+        "debug help should list cleanup debug section"
+    );
+    assert!(
+        stdout.contains("--no-reset"),
+        "debug help should surface no-reset flag"
+    );
+    assert!(
+        stdout.contains("--cleanup-aggressive"),
+        "debug help should list cleanup-aggressive flag"
+    );
+    assert!(
+        stdout.contains("Debug / stream overrides"),
+        "debug help should list stream override section"
+    );
+    assert!(
+        stdout.contains("--fe_stream_override"),
+        "debug help should list stream override flag"
+    );
 }
 
 #[test]
@@ -98,30 +138,30 @@ fn analysis_threshold_flags_require_debug_mode() {
 }
 
 #[test]
-fn fast_export_debug_flags_require_debug_mode() {
-    let gated_flags = [
-        "--date-order",
-        "--no-reencode",
-        "--no-quotepath",
-        "--no-mark-tags",
-        "--mark-tags",
+fn debug_only_flags_require_debug_mode() {
+    let gated_cases: &[(&[&str], &str)] = &[
+        (&["--date-order"], "--date-order"),
+        (&["--no-reencode"], "--no-reencode"),
+        (&["--no-quotepath"], "--no-quotepath"),
+        (&["--no-mark-tags"], "--no-mark-tags"),
+        (&["--mark-tags"], "--mark-tags"),
+        (&["--no-reset"], "--no-reset"),
+        (&["--cleanup-aggressive"], "--cleanup-aggressive"),
+        (&["--fe_stream_override", "dummy"], "--fe_stream_override"),
     ];
 
-    for flag in gated_flags {
-        let output = cli_command()
-            .arg(flag)
-            .output()
-            .unwrap_or_else(|e| {
-                panic!(
-                    "failed to run filter-repo-rs with gated flag {}: {}",
-                    flag, e
-                )
-            });
+    for &(args, flag) in gated_cases {
+        let output = cli_command().args(args).output().unwrap_or_else(|e| {
+            panic!(
+                "failed to run filter-repo-rs with gated flag {}: {}",
+                flag, e
+            )
+        });
 
         assert_eq!(
             Some(2),
             output.status.code(),
-            "gated fast-export flag '{}' should exit with code 2",
+            "gated flag '{}' should exit with code 2",
             flag
         );
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -134,19 +174,22 @@ fn fast_export_debug_flags_require_debug_mode() {
 }
 
 #[test]
-fn debug_mode_allows_fast_export_debug_flags() {
-    let gated_flags = [
-        "--date-order",
-        "--no-reencode",
-        "--no-quotepath",
-        "--no-mark-tags",
-        "--mark-tags",
+fn debug_mode_allows_debug_only_flags() {
+    let gated_cases: &[(&[&str], &str)] = &[
+        (&["--date-order"], "--date-order"),
+        (&["--no-reencode"], "--no-reencode"),
+        (&["--no-quotepath"], "--no-quotepath"),
+        (&["--no-mark-tags"], "--no-mark-tags"),
+        (&["--mark-tags"], "--mark-tags"),
+        (&["--no-reset"], "--no-reset"),
+        (&["--cleanup-aggressive"], "--cleanup-aggressive"),
+        (&["--fe_stream_override", "dummy"], "--fe_stream_override"),
     ];
 
-    for flag in gated_flags {
+    for &(args, flag) in gated_cases {
         let output = cli_command()
             .arg("--debug-mode")
-            .arg(flag)
+            .args(args)
             .arg("--help")
             .output()
             .unwrap_or_else(|e| {
@@ -158,7 +201,7 @@ fn debug_mode_allows_fast_export_debug_flags() {
 
         assert!(
             output.status.success(),
-            "debug mode should allow fast-export flag '{}'",
+            "debug mode should allow flag '{}'",
             flag
         );
     }


### PR DESCRIPTION
## Summary
- gate `--no-reset`, `--cleanup-aggressive`, and `--fe_stream_override` behind debug mode and reorganize help output to hide debug-only sections
- enforce debug-mode usage when overriding fast-export streams and update CLI help printing to split debug sections
- expand CLI and stream tests to cover new gating, debug help exposure, and the stream override guard

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf82e5863c8332b5bb5fde23e20813