### PR TITLE
Make --cleanup a boolean flag and deprecate legacy modes

### DIFF
--- a/filter-repo-rs/src/finalize.rs
+++ b/filter-repo-rs/src/finalize.rs
@@ -328,25 +328,11 @@ pub fn finalize(
     if !opts.dry_run {
         match opts.cleanup {
             crate::opts::CleanupMode::None => {}
-            crate::opts::CleanupMode::Standard | crate::opts::CleanupMode::Aggressive => {
-                let _ = Command::new("git")
-                    .arg("-C")
-                    .arg(&opts.target)
-                    .arg("reflog")
-                    .arg("expire")
-                    .arg("--expire=now")
-                    .arg("--all")
-                    .status();
-                let mut gc = Command::new("git");
-                gc.arg("-C")
-                    .arg(&opts.target)
-                    .arg("gc")
-                    .arg("--prune=now")
-                    .arg("--quiet");
-                if matches!(opts.cleanup, crate::opts::CleanupMode::Aggressive) {
-                    gc.arg("--aggressive");
-                }
-                let _ = gc.status();
+            crate::opts::CleanupMode::Standard => {
+                run_repo_cleanup(&opts.target, false);
+            }
+            crate::opts::CleanupMode::Aggressive => {
+                run_repo_cleanup(&opts.target, true);
             }
         }
     }
@@ -686,6 +672,32 @@ pub fn finalize(
     // Post-run remote cleanup (non-sensitive parity): remove origin
     migrate::remove_origin_remote_if_applicable(opts);
     Ok(())
+}
+
+fn run_repo_cleanup(target: &Path, aggressive: bool) {
+    let mut reflog = Command::new("git");
+    reflog
+        .arg("-C")
+        .arg(target)
+        .arg("reflog")
+        .arg("expire")
+        .arg("--expire=now");
+    if aggressive {
+        reflog.arg("--expire-unreachable=now");
+    }
+    reflog.arg("--all");
+    let _ = reflog.status();
+
+    let mut gc = Command::new("git");
+    gc.arg("-C")
+        .arg(target)
+        .arg("gc")
+        .arg("--prune=now")
+        .arg("--quiet");
+    if aggressive {
+        gc.arg("--aggressive");
+    }
+    let _ = gc.status();
 }
 
 fn resolve_reset_target(

--- a/filter-repo-rs/src/finalize.rs
+++ b/filter-repo-rs/src/finalize.rs
@@ -686,7 +686,13 @@ fn run_repo_cleanup(target: &Path, aggressive: bool) {
         reflog.arg("--expire-unreachable=now");
     }
     reflog.arg("--all");
-    let _ = reflog.status();
+    match reflog.status() {
+        Ok(status) if !status.success() => {
+            eprintln!("warning: git reflog expire failed: {}", status);
+        }
+        Err(e) => eprintln!("warning: failed to execute git reflog expire: {}", e),
+        _ => {}
+    }
 
     let mut gc = Command::new("git");
     gc.arg("-C")

--- a/filter-repo-rs/src/finalize.rs
+++ b/filter-repo-rs/src/finalize.rs
@@ -703,7 +703,13 @@ fn run_repo_cleanup(target: &Path, aggressive: bool) {
     if aggressive {
         gc.arg("--aggressive");
     }
-    let _ = gc.status();
+    match gc.status() {
+        Ok(status) if !status.success() => {
+            eprintln!("warning: git gc failed: {}", status);
+        }
+        Err(e) => eprintln!("warning: failed to execute git gc: {}", e),
+        _ => {}
+    }
 }
 
 fn resolve_reset_target(

--- a/filter-repo-rs/src/opts.rs
+++ b/filter-repo-rs/src/opts.rs
@@ -310,19 +310,22 @@ pub fn parse_args() -> Options {
         opts.write_report = true;
       }
       "--cleanup" => {
-        let v = it.next().expect("--cleanup requires one of: none|standard|aggressive");
-        opts.cleanup = match v.as_str() {
-          "none" => CleanupMode::None,
-          "standard" => CleanupMode::Standard,
-          "aggressive" => {
-            guard_debug("--cleanup aggressive", opts.debug_mode);
-            CleanupMode::Aggressive
+        if let Some(next) = it.clone().next() {
+          if matches!(next.as_str(), "none" | "standard" | "aggressive") {
+            let legacy = it.next().expect("--cleanup legacy value consumed");
+            parse_legacy_cleanup_value(&legacy, &mut opts);
+            continue;
           }
-          other => {
-            eprintln!("--cleanup: unknown mode '{}'", other);
-            std::process::exit(2);
-          }
-        };
+        }
+        opts.cleanup = CleanupMode::Standard;
+      }
+      arg if arg.starts_with("--cleanup=") => {
+        let value = &arg[10..];
+        if value.is_empty() {
+          eprintln!("--cleanup= requires a value of none|standard|aggressive");
+          std::process::exit(2);
+        }
+        parse_legacy_cleanup_value(value, &mut opts);
       }
       "--cleanup-aggressive" => {
         guard_debug("--cleanup-aggressive", opts.debug_mode);
@@ -390,6 +393,47 @@ pub fn parse_args() -> Options {
     }
   }
   opts
+}
+
+fn parse_legacy_cleanup_value(value: &str, opts: &mut Options) {
+  warn_legacy_cleanup_usage(value);
+  opts.cleanup = match value {
+    "none" => CleanupMode::None,
+    "standard" => CleanupMode::Standard,
+    "aggressive" => {
+      guard_debug("--cleanup aggressive", opts.debug_mode);
+      CleanupMode::Aggressive
+    }
+    other => {
+      eprintln!("--cleanup: unknown mode '{}'", other);
+      std::process::exit(2);
+    }
+  };
+}
+
+fn warn_legacy_cleanup_usage(mode: &str) {
+  use std::collections::HashSet;
+  use std::sync::{Mutex, OnceLock};
+
+  static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+  let mut warned = WARNED.get_or_init(|| Mutex::new(HashSet::new())).lock().unwrap();
+  let key = format!("cleanup:{mode}");
+  if !warned.insert(key) {
+    return;
+  }
+
+  let recommendation = match mode {
+    "none" => "omit --cleanup entirely (cleanup defaults to 'none').",
+    "standard" => "use --cleanup (without a value) to enable standard cleanup.",
+    "aggressive" => "use --cleanup-aggressive (requires --debug-mode or FRRS_DEBUG=1).",
+    _ => "use --cleanup or --cleanup-aggressive instead.",
+  };
+
+  eprintln!(
+    "warning: --cleanup with an explicit value is deprecated; {}",
+    recommendation
+  );
+  eprintln!("note: pass --cleanup as a boolean flag for standard cleanup.");
 }
 
 fn debug_mode_enabled(args: &[String]) -> bool {
@@ -462,7 +506,8 @@ Commit, tag & ref updates:\n\
 \n\
 Execution behavior & output:\n\
   --write-report              Write .git/filter-repo/report.txt summary\n\
-  --cleanup MODE              none|standard|aggressive (default: none)\n\
+  --cleanup                   Run post-import cleanup (reflog expire + git gc)\n\
+                              (disabled by default)\n\
   --quiet                     Reduce output noise\n\
   --force, -f                 Bypass safety prompts and checks where applicable\n\
   --enforce-sanity            Fail early unless repo passes strict preflight\n\
@@ -514,7 +559,8 @@ Debug / analysis thresholds (require --debug-mode or FRRS_DEBUG=1):\n\
 const DEBUG_CLEANUP_HELP: &str = "\n\
 Debug / cleanup behavior (require --debug-mode or FRRS_DEBUG=1):\n\
   --no-reset                  Skip final 'git reset --hard' in target\n\
-  --cleanup-aggressive        Apply aggressive cleanup routines after filtering\n\
+  --cleanup-aggressive        Extend cleanup with git gc --aggressive and\n\
+                              --expire-unreachable=now\n\
 ";
 
 const DEBUG_STREAM_HELP: &str = "\n\

--- a/filter-repo-rs/src/opts.rs
+++ b/filter-repo-rs/src/opts.rs
@@ -416,7 +416,7 @@ fn warn_legacy_cleanup_usage(mode: &str) {
   use std::sync::{Mutex, OnceLock};
 
   static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-  let mut warned = WARNED.get_or_init(|| Mutex::new(HashSet::new())).lock().unwrap();
+  let mut warned = WARNED.get_or_init(|| Mutex::new(HashSet::new())).lock().expect("Mutex poisoned");
   let key = format!("cleanup:{mode}");
   if !warned.insert(key) {
     return;

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -225,3 +225,59 @@ fn debug_mode_allows_analysis_threshold_flags() {
         "debug mode should allow threshold overrides"
     );
 }
+
+#[test]
+fn cleanup_flag_supports_new_and_legacy_syntax() {
+    let repo = init_repo();
+
+    let legacy_eq = cli_command()
+        .arg("--cleanup=standard")
+        .arg("--dry-run")
+        .current_dir(&repo)
+        .output()
+        .expect("run filter-repo-rs with legacy cleanup syntax (--cleanup=standard)");
+
+    assert!(legacy_eq.status.success(), "legacy cleanup syntax should still run");
+    let stderr_eq = String::from_utf8_lossy(&legacy_eq.stderr);
+    assert!(
+        stderr_eq.contains("deprecated"),
+        "legacy --cleanup= mode should emit deprecation warning: {}",
+        stderr_eq
+    );
+    assert!(
+        stderr_eq.contains("--cleanup"),
+        "deprecation warning should mention --cleanup guidance: {}",
+        stderr_eq
+    );
+
+    let legacy_split = cli_command()
+        .arg("--cleanup")
+        .arg("none")
+        .arg("--dry-run")
+        .current_dir(&repo)
+        .output()
+        .expect("run filter-repo-rs with legacy cleanup syntax (--cleanup none)");
+
+    assert!(legacy_split.status.success(), "legacy split cleanup syntax should run");
+    let stderr_split = String::from_utf8_lossy(&legacy_split.stderr);
+    assert!(
+        stderr_split.contains("deprecated"),
+        "legacy split syntax should emit deprecation warning: {}",
+        stderr_split
+    );
+
+    let new_flag = cli_command()
+        .arg("--cleanup")
+        .arg("--dry-run")
+        .current_dir(&repo)
+        .output()
+        .expect("run filter-repo-rs with boolean --cleanup");
+
+    assert!(new_flag.status.success(), "boolean --cleanup should succeed");
+    let stderr_new = String::from_utf8_lossy(&new_flag.stderr);
+    assert!(
+        !stderr_new.contains("deprecated"),
+        "boolean --cleanup should not emit deprecation warning: {}",
+        stderr_new
+    );
+}

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -266,6 +266,27 @@ fn cleanup_flag_supports_new_and_legacy_syntax() {
         stderr_split
     );
 
+    let legacy_agg = cli_command()
+        .arg("--debug-mode")
+        .arg("--cleanup=aggressive")
+        .arg("--dry-run")
+        .current_dir(&repo)
+        .output()
+        .expect("run filter-repo-rs with legacy cleanup syntax (--cleanup=aggressive)");
+
+    assert!(legacy_agg.status.success(), "legacy aggressive cleanup syntax should run");
+    let stderr_agg = String::from_utf8_lossy(&legacy_agg.stderr);
+    assert!(
+        stderr_agg.contains("deprecated"),
+        "legacy --cleanup=aggressive mode should emit deprecation warning: {}",
+        stderr_agg
+    );
+    assert!(
+        stderr_agg.contains("--cleanup-aggressive"),
+        "deprecation warning for aggressive should mention --cleanup-aggressive: {}",
+        stderr_agg
+    );
+
     let new_flag = cli_command()
         .arg("--cleanup")
         .arg("--dry-run")


### PR DESCRIPTION
## Summary
- treat `--cleanup` as a boolean that enables standard cleanup and surface a dedicated warning path for legacy `--cleanup=<mode>` syntax
- update finalize cleanup execution to share a helper that adds `--expire-unreachable=now`/`--aggressive` when requested
- extend CLI tests to cover the new flag behavior and legacy warnings

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf94fa12ec83329dfcfab02be4af6a