### PR TITLE
Warn on legacy analysis threshold CLI usage

### DIFF
--- a/docs/CLI-CONVERGENCE.zh-CN.md
+++ b/docs/CLI-CONVERGENCE.zh-CN.md
@@ -62,19 +62,19 @@ CLI 收敛草案（filter-repo-rs）
 top = 10
 
 [analyze.thresholds]
-total_warn = 1073741824        # 1 GiB
-total_critical = 5368709120    # 5 GiB
-blob_warn = 10485760           # 10 MiB
-ref_warn = 20000
-object_warn = 10000000
-tree_entries_warn = 2000
-path_length_warn = 200
-duplicate_paths_warn = 1000
-commit_msg_warn = 10000
-max_parents_warn = 8
+warn_total_bytes = 1073741824        # 1 GiB
+crit_total_bytes = 5368709120        # 5 GiB
+warn_blob_bytes = 10485760           # 10 MiB
+warn_ref_count = 20000
+warn_object_count = 10000000
+warn_tree_entries = 2000
+warn_path_length = 200
+warn_duplicate_paths = 1000
+warn_commit_msg_bytes = 10000
+warn_max_parents = 8
 ```
 
-- CLI 若显式传入阈值，则覆盖配置文件；否则按配置/默认。
+- CLI 若显式传入阈值，则覆盖配置文件；否则按配置/默认。旧 CLI 阈值旗标进入弃用阶段（见下文“迁移指南”）。
 
 五、弃用与兼容策略
 -------------------
@@ -87,6 +87,26 @@ max_parents_warn = 8
 - `--cleanup aggressive` → 在调试模式使用 `--cleanup-aggressive`（隐藏）；常规场景推荐仅 `--cleanup`。
 - `--no-reset` → 由 `--dry-run` 覆盖；调试模式可显式使用。
 - 分析阈值族 → 对应配置文件键值；CLI 仅保留 `--analyze(-json/top)`。
+
+迁移指南（阶段 1 → 阶段 2）：
+
+| 旧旗标/语法 | 推荐替代 | 告警文案摘要 |
+| --- | --- | --- |
+| `--cleanup=none` | 直接省略 `--cleanup`，保持默认无清理 | `warning: --cleanup=none is deprecated; simply omit --cleanup to keep cleanup disabled.` |
+| `--cleanup=standard` | 使用布尔型 `--cleanup` | `warning: --cleanup=standard is deprecated; use --cleanup (boolean) to request standard cleanup.` |
+| `--cleanup=aggressive` | 在调试模式使用 `--cleanup-aggressive` | `warning: --cleanup=aggressive is deprecated; use --cleanup-aggressive in debug mode if you need the old aggressive behavior.` |
+| `--analyze-total-warn BYTES` | `analyze.thresholds.warn_total_bytes` | `warning: --analyze-total-warn is deprecated; set analyze.thresholds.warn_total_bytes in your .filter-repo-rs.toml (or --config) file instead.` |
+| `--analyze-total-critical BYTES` | `analyze.thresholds.crit_total_bytes` | 同上模式，指向相应配置键 |
+| `--analyze-large-blob BYTES` | `analyze.thresholds.warn_blob_bytes` | 同上模式 |
+| `--analyze-ref-warn COUNT` | `analyze.thresholds.warn_ref_count` | 同上模式 |
+| `--analyze-object-warn COUNT` | `analyze.thresholds.warn_object_count` | 同上模式 |
+| `--analyze-tree-entries N` | `analyze.thresholds.warn_tree_entries` | 同上模式 |
+| `--analyze-path-length N` | `analyze.thresholds.warn_path_length` | 同上模式 |
+| `--analyze-duplicate-paths N` | `analyze.thresholds.warn_duplicate_paths` | 同上模式 |
+| `--analyze-commit-msg-warn N` | `analyze.thresholds.warn_commit_msg_bytes` | 同上模式 |
+| `--analyze-max-parents-warn N` | `analyze.thresholds.warn_max_parents` | 同上模式 |
+
+> 以上告警仅会打印一次，并附带 `note: see docs/CLI-CONVERGENCE.zh-CN.md for the analysis threshold migration table.`，便于脚本在阶段 1/2 内更新。
 
 六、帮助文本分层
 ----------------

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -106,7 +106,8 @@ A minimal Rust prototype of git-filter-repo is working end-to-end on real reposi
 ## CLI Convergence
 
 - See docs/CLI-CONVERGENCE.zh-CN.md for the proposed CLI consolidation plan (core vs. hidden/debug, merged semantics, config file for analysis thresholds, and deprecation strategy).
-- Analysis threshold "micro-tuning" flags (`--analyze-*-warn`) are now hidden by default and require `--debug-mode` or `FRRS_DEBUG=1`; core help surfaces only `--analyze`, `--analyze-json`, and `--analyze-top`.
+- Analysis threshold "micro-tuning" flags (`--analyze-*-warn`) are now hidden by default and require `--debug-mode` or `FRRS_DEBUG=1`; core help surfaces only `--analyze`, `--analyze-json`, and `--analyze-top`. As of the latest prototype, these legacy flags emit a one-time warning pointing to `analyze.thresholds.*` config keys, and the help text references them only as compatibility shims.
+- Legacy `--cleanup=<mode>` syntax continues to parse for now, but prints a one-time warning steering users to the boolean `--cleanup` or debug-only `--cleanup-aggressive`. Stage-3 toggles exist in the parser to disable the legacy syntax once compatibility can be removed.
 
 ## MVP Scope (target) and Gap
 

--- a/filter-repo-rs/src/opts.rs
+++ b/filter-repo-rs/src/opts.rs
@@ -4,6 +4,11 @@ use std::path::{Path, PathBuf};
 use regex::bytes::Regex;
 use serde::Deserialize;
 
+/// Stage-3 toggle: set to `false` to error out instead of accepting legacy cleanup syntax.
+const LEGACY_CLEANUP_SYNTAX_ALLOWED: bool = true;
+/// Stage-3 toggle: set to `false` to disable legacy --analyze-*-warn overrides entirely.
+const LEGACY_ANALYZE_THRESHOLD_FLAGS_ALLOWED: bool = true;
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CleanupMode { None, Standard, Aggressive }
@@ -255,70 +260,80 @@ pub fn parse_args() -> Options {
         overrides.top = Some(top);
       }
       "--analyze-total-warn" => {
-        guard_debug("--analyze-total-warn", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-total-warn", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-total-warn", "analyze.thresholds.warn_total_bytes");
         let v = it.next().expect("--analyze-total-warn requires BYTES");
         let parsed = parse_u64(&v, "--analyze-total-warn");
         opts.analyze.thresholds.warn_total_bytes = parsed;
         overrides.thresholds.warn_total_bytes = Some(parsed);
       }
       "--analyze-total-critical" => {
-        guard_debug("--analyze-total-critical", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-total-critical", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-total-critical", "analyze.thresholds.crit_total_bytes");
         let v = it.next().expect("--analyze-total-critical requires BYTES");
         let parsed = parse_u64(&v, "--analyze-total-critical");
         opts.analyze.thresholds.crit_total_bytes = parsed;
         overrides.thresholds.crit_total_bytes = Some(parsed);
       }
       "--analyze-large-blob" => {
-        guard_debug("--analyze-large-blob", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-large-blob", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-large-blob", "analyze.thresholds.warn_blob_bytes");
         let v = it.next().expect("--analyze-large-blob requires BYTES");
         let parsed = parse_u64(&v, "--analyze-large-blob");
         opts.analyze.thresholds.warn_blob_bytes = parsed;
         overrides.thresholds.warn_blob_bytes = Some(parsed);
       }
       "--analyze-ref-warn" => {
-        guard_debug("--analyze-ref-warn", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-ref-warn", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-ref-warn", "analyze.thresholds.warn_ref_count");
         let v = it.next().expect("--analyze-ref-warn requires COUNT");
         let parsed = parse_usize(&v, "--analyze-ref-warn");
         opts.analyze.thresholds.warn_ref_count = parsed;
         overrides.thresholds.warn_ref_count = Some(parsed);
       }
       "--analyze-object-warn" => {
-        guard_debug("--analyze-object-warn", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-object-warn", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-object-warn", "analyze.thresholds.warn_object_count");
         let v = it.next().expect("--analyze-object-warn requires COUNT");
         let parsed = parse_usize(&v, "--analyze-object-warn");
         opts.analyze.thresholds.warn_object_count = parsed;
         overrides.thresholds.warn_object_count = Some(parsed);
       }
       "--analyze-tree-entries" => {
-        guard_debug("--analyze-tree-entries", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-tree-entries", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-tree-entries", "analyze.thresholds.warn_tree_entries");
         let v = it.next().expect("--analyze-tree-entries requires COUNT");
         let parsed = parse_usize(&v, "--analyze-tree-entries");
         opts.analyze.thresholds.warn_tree_entries = parsed;
         overrides.thresholds.warn_tree_entries = Some(parsed);
       }
       "--analyze-path-length" => {
-        guard_debug("--analyze-path-length", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-path-length", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-path-length", "analyze.thresholds.warn_path_length");
         let v = it.next().expect("--analyze-path-length requires LENGTH");
         let parsed = parse_usize(&v, "--analyze-path-length");
         opts.analyze.thresholds.warn_path_length = parsed;
         overrides.thresholds.warn_path_length = Some(parsed);
       }
       "--analyze-duplicate-paths" => {
-        guard_debug("--analyze-duplicate-paths", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-duplicate-paths", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-duplicate-paths", "analyze.thresholds.warn_duplicate_paths");
         let v = it.next().expect("--analyze-duplicate-paths requires COUNT");
         let parsed = parse_usize(&v, "--analyze-duplicate-paths");
         opts.analyze.thresholds.warn_duplicate_paths = parsed;
         overrides.thresholds.warn_duplicate_paths = Some(parsed);
       }
       "--analyze-commit-msg-warn" => {
-        guard_debug("--analyze-commit-msg-warn", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-commit-msg-warn", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-commit-msg-warn", "analyze.thresholds.warn_commit_msg_bytes");
         let v = it.next().expect("--analyze-commit-msg-warn requires BYTES");
         let parsed = parse_usize(&v, "--analyze-commit-msg-warn");
         opts.analyze.thresholds.warn_commit_msg_bytes = parsed;
         overrides.thresholds.warn_commit_msg_bytes = Some(parsed);
       }
       "--analyze-max-parents-warn" => {
-        guard_debug("--analyze-max-parents-warn", opts.debug_mode);
+        enforce_legacy_analyze_flag_allowed("--analyze-max-parents-warn", opts.debug_mode);
+        warn_legacy_analyze_threshold("--analyze-max-parents-warn", "analyze.thresholds.warn_max_parents");
         let v = it.next().expect("--analyze-max-parents-warn requires COUNT");
         let parsed = parse_usize(&v, "--analyze-max-parents-warn");
         opts.analyze.thresholds.warn_max_parents = parsed;
@@ -569,6 +584,7 @@ fn apply_config_from_file(opts: &mut Options, path: &Path) -> Result<(), ConfigE
 }
 
 fn parse_legacy_cleanup_value(value: &str, opts: &mut Options) {
+  enforce_legacy_cleanup_allowed();
   warn_legacy_cleanup_usage(value);
   opts.cleanup = match value {
     "none" => CleanupMode::None,
@@ -585,28 +601,75 @@ fn parse_legacy_cleanup_value(value: &str, opts: &mut Options) {
 }
 
 fn warn_legacy_cleanup_usage(mode: &str) {
+  if !legacy_warning_once(&format!("cleanup:{mode}")) {
+    return;
+  }
+
+  match mode {
+    "none" => {
+      eprintln!(
+        "warning: --cleanup=none is deprecated; simply omit --cleanup to keep cleanup disabled."
+      );
+    }
+    "standard" => {
+      eprintln!(
+        "warning: --cleanup=standard is deprecated; use --cleanup (boolean) to request standard cleanup."
+      );
+    }
+    "aggressive" => {
+      eprintln!(
+        "warning: --cleanup=aggressive is deprecated; use --cleanup-aggressive in debug mode if you need the old aggressive behavior."
+      );
+    }
+    _ => {
+      eprintln!(
+        "warning: --cleanup with an explicit value is deprecated; use --cleanup or --cleanup-aggressive instead."
+      );
+    }
+  }
+  eprintln!("note: see docs/CLI-CONVERGENCE.zh-CN.md for the cleanup migration guide.");
+}
+
+fn legacy_warning_once(key: &str) -> bool {
   use std::collections::HashSet;
   use std::sync::{Mutex, OnceLock};
 
   static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-  let mut warned = WARNED.get_or_init(|| Mutex::new(HashSet::new())).lock().expect("Mutex poisoned");
-  let key = format!("cleanup:{mode}");
-  if !warned.insert(key) {
+  WARNED
+    .get_or_init(|| Mutex::new(HashSet::new()))
+    .lock()
+    .expect("Mutex poisoned")
+    .insert(key.to_string())
+}
+
+fn enforce_legacy_cleanup_allowed() {
+  if LEGACY_CLEANUP_SYNTAX_ALLOWED {
     return;
   }
 
-  let recommendation = match mode {
-    "none" => "omit --cleanup entirely (cleanup defaults to 'none').",
-    "standard" => "use --cleanup (without a value) to enable standard cleanup.",
-    "aggressive" => "use --cleanup-aggressive (requires --debug-mode or FRRS_DEBUG=1).",
-    _ => "use --cleanup or --cleanup-aggressive instead.",
-  };
+  eprintln!("error: legacy --cleanup=<mode> syntax has been removed; use --cleanup or --cleanup-aggressive.");
+  std::process::exit(2);
+}
+
+fn enforce_legacy_analyze_flag_allowed(flag: &str, debug_mode: bool) {
+  if !LEGACY_ANALYZE_THRESHOLD_FLAGS_ALLOWED {
+    eprintln!(
+      "error: {flag} is no longer accepted; configure analyze.thresholds.* in your filter-repo-rs config file instead."
+    );
+    std::process::exit(2);
+  }
+  guard_debug(flag, debug_mode);
+}
+
+fn warn_legacy_analyze_threshold(flag: &str, config_key: &str) {
+  if !legacy_warning_once(flag) {
+    return;
+  }
 
   eprintln!(
-    "warning: --cleanup with an explicit value is deprecated; {}",
-    recommendation
+    "warning: {flag} is deprecated; set {config_key} in your .filter-repo-rs.toml (or --config) file instead."
   );
-  eprintln!("note: pass --cleanup as a boolean flag for standard cleanup.");
+  eprintln!("note: see docs/CLI-CONVERGENCE.zh-CN.md for the analysis threshold migration table.");
 }
 
 fn debug_mode_enabled(args: &[String]) -> bool {
@@ -717,16 +780,8 @@ Debug / fast-export passthrough (require --debug-mode or FRRS_DEBUG=1):\n\
 
 const DEBUG_ANALYSIS_HELP: &str = "\n\
 Debug / analysis thresholds (require --debug-mode or FRRS_DEBUG=1):\n\
-  --analyze-total-warn BYTES  Override warning threshold for total repo size\n\
-  --analyze-total-critical BYTES Override critical threshold for total repo size\n\
-  --analyze-large-blob BYTES  Override blob size warning threshold\n\
-  --analyze-ref-warn COUNT    Override reference count warning threshold\n\
-  --analyze-object-warn COUNT Override object count warning threshold\n\
-  --analyze-tree-entries N    Override tree entry warning threshold\n\
-  --analyze-path-length N     Override path length warning threshold\n\
-  --analyze-duplicate-paths N Override duplicate-path warning threshold\n\
-  --analyze-commit-msg-warn N Override commit message length warning threshold\n\
-  --analyze-max-parents-warn N Override max parent count warning threshold\n\
+  Configure analyze.thresholds.* via .filter-repo-rs.toml or --config.\n\
+  Legacy --analyze-*-warn CLI flags remain for compatibility but emit warnings.\n\
 ";
 
 const DEBUG_CLEANUP_HELP: &str = "\n\

--- a/filter-repo-rs/src/opts.rs
+++ b/filter-repo-rs/src/opts.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use regex::bytes::Regex;
 use serde::Deserialize;
@@ -631,15 +633,10 @@ fn warn_legacy_cleanup_usage(mode: &str) {
 }
 
 fn legacy_warning_once(key: &str) -> bool {
-  use std::collections::HashSet;
-  use std::sync::{Mutex, OnceLock};
-
   static WARNED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-  WARNED
-    .get_or_init(|| Mutex::new(HashSet::new()))
-    .lock()
-    .expect("Mutex poisoned")
-    .insert(key.to_string())
+  let warned_set = WARNED.get_or_init(|| Mutex::new(HashSet::new()));
+  let mut warned = warned_set.lock().expect("Mutex poisoned");
+  warned.insert(key.to_string())
 }
 
 fn enforce_legacy_cleanup_allowed() {

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -76,12 +76,20 @@ fn help_shows_debug_sections_in_debug_mode() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("--analyze-total-warn"),
-        "debug help should list threshold flag"
-    );
-    assert!(
         stdout.contains("Debug / analysis thresholds"),
         "debug section header missing"
+    );
+    assert!(
+        stdout.contains("Configure analyze.thresholds.* via"),
+        "debug help should mention config guidance for thresholds"
+    );
+    assert!(
+        stdout.contains("Legacy --analyze-*-warn CLI flags remain for compatibility"),
+        "debug help should include legacy compatibility note"
+    );
+    assert!(
+        !stdout.contains("--analyze-total-warn"),
+        "debug help should omit direct legacy flag listing"
     );
     assert!(
         stdout.contains("Debug / fast-export passthrough"),
@@ -237,7 +245,10 @@ fn cleanup_flag_supports_new_and_legacy_syntax() {
         .output()
         .expect("run filter-repo-rs with legacy cleanup syntax (--cleanup=standard)");
 
-    assert!(legacy_eq.status.success(), "legacy cleanup syntax should still run");
+    assert!(
+        legacy_eq.status.success(),
+        "legacy cleanup syntax should still run"
+    );
     let stderr_eq = String::from_utf8_lossy(&legacy_eq.stderr);
     assert!(
         stderr_eq.contains("deprecated"),
@@ -258,7 +269,10 @@ fn cleanup_flag_supports_new_and_legacy_syntax() {
         .output()
         .expect("run filter-repo-rs with legacy cleanup syntax (--cleanup none)");
 
-    assert!(legacy_split.status.success(), "legacy split cleanup syntax should run");
+    assert!(
+        legacy_split.status.success(),
+        "legacy split cleanup syntax should run"
+    );
     let stderr_split = String::from_utf8_lossy(&legacy_split.stderr);
     assert!(
         stderr_split.contains("deprecated"),
@@ -274,7 +288,10 @@ fn cleanup_flag_supports_new_and_legacy_syntax() {
         .output()
         .expect("run filter-repo-rs with legacy cleanup syntax (--cleanup=aggressive)");
 
-    assert!(legacy_agg.status.success(), "legacy aggressive cleanup syntax should run");
+    assert!(
+        legacy_agg.status.success(),
+        "legacy aggressive cleanup syntax should run"
+    );
     let stderr_agg = String::from_utf8_lossy(&legacy_agg.stderr);
     assert!(
         stderr_agg.contains("deprecated"),
@@ -294,7 +311,10 @@ fn cleanup_flag_supports_new_and_legacy_syntax() {
         .output()
         .expect("run filter-repo-rs with boolean --cleanup");
 
-    assert!(new_flag.status.success(), "boolean --cleanup should succeed");
+    assert!(
+        new_flag.status.success(),
+        "boolean --cleanup should succeed"
+    );
     let stderr_new = String::from_utf8_lossy(&new_flag.stderr);
     assert!(
         !stderr_new.contains("deprecated"),


### PR DESCRIPTION
## Summary
- add stage-3 toggles plus one-time warnings for legacy `--cleanup=<mode>` and `--analyze-*-warn` flags while keeping compatibility
- trim debug help output to describe config-based threshold overrides and highlight legacy compatibility
- document the new warning text and migration mapping in the CLI convergence guide and status tracker

## Testing
- cargo test -p filter-repo-rs

------
https://chatgpt.com/codex/tasks/task_e_68cfabb6069c83328648bde1d11517f9