### PR TITLE
Allow underscores in max-blob-size argument

### DIFF
--- a/filter-repo-rs/src/opts.rs
+++ b/filter-repo-rs/src/opts.rs
@@ -758,7 +758,7 @@ fn guard_debug(flag: &str, debug_mode: bool) {
     }
 }
 
-fn parse_integer_allowing_underscores<T>(s: &str) -> Result<T, ()>
+fn parse_integer_allowing_underscores<T>(s: &str) -> Result<T, T::Err>
 where
     T: std::str::FromStr,
 {
@@ -768,7 +768,7 @@ where
         Cow::Borrowed(s)
     };
 
-    normalized.parse::<T>().map_err(|_| ())
+    normalized.parse::<T>()
 }
 
 fn parse_u64(s: &str, flag: &str) -> u64 {

--- a/filter-repo-rs/tests/cli.rs
+++ b/filter-repo-rs/tests/cli.rs
@@ -120,6 +120,35 @@ fn help_shows_debug_sections_in_debug_mode() {
 }
 
 #[test]
+fn max_blob_size_accepts_numeric_underscores() {
+    let output = cli_command()
+        .arg("--max-blob-size")
+        .arg("2_120_000")
+        .arg("--help")
+        .output()
+        .expect("run filter-repo-rs --max-blob-size with underscores");
+
+    assert!(
+        output.status.success(),
+        "max-blob-size with underscores should succeed"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Usage: filter-repo-rs"),
+        "help output should be printed when requesting --help; got: {}",
+        stdout
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("expects an integer"),
+        "unexpected parse error in stderr: {}",
+        stderr
+    );
+}
+
+#[test]
 fn env_toggle_enables_debug_help() {
     let output = cli_command()
         .env("FRRS_DEBUG", "1")


### PR DESCRIPTION
## Summary
- allow numeric CLI parsing to accept underscore separators
- add a CLI regression test covering `--max-blob-size` with underscores

## Testing
- cargo test -p filter-repo-rs

------
https://chatgpt.com/codex/tasks/task_e_68d003e1cad88332a4392488f59dfbc1